### PR TITLE
Using mobx's createAtom to augment remult's entity and use active record pattern

### DIFF
--- a/db/tasks.json
+++ b/db/tasks.json
@@ -26,7 +26,7 @@
   },
   {
     "id": "94c14437-ac2c-405b-931c-16659d271468",
-    "title": "jl;jkl;123456",
+    "title": "jl;jkl;",
     "completed": false
   }
 ]

--- a/db/tasks.json
+++ b/db/tasks.json
@@ -26,7 +26,7 @@
   },
   {
     "id": "94c14437-ac2c-405b-931c-16659d271468",
-    "title": "jl;jkl;",
+    "title": "jl;jkl;123456",
     "completed": false
   }
 ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { remult } from "remult";
+import { Remult, remult } from "remult";
 import { Task } from "./shared/Task";
 import { TasksController } from "./shared/TasksController";
 import { observer } from "mobx-react-lite";
-import { action, makeAutoObservable, observable, runInAction } from 'mobx';
+import { action, makeAutoObservable, observable, runInAction, createAtom } from 'mobx';
 
 
-
+Remult.entityRefInit = (ref, row) => ref.subscribe(createAtom("entity"));
 
 class Store {
   taskRepo = remult.repo(Task);
@@ -16,7 +16,7 @@ class Store {
     makeAutoObservable(this);
   }
   replaceTasks(t: Task[]) {
-    this.tasks.replace(t.map(t => makeAutoObservable({ ...t })));
+    this.tasks.replace(t);
   }
   async loadTasks() {
     this.replaceTasks(await
@@ -27,7 +27,7 @@ class Store {
       }));
   }
   addTask() {
-    this.tasks.push(makeAutoObservable(new Task()))
+    this.tasks.push(this.taskRepo.create())
   }
   async saveTask(task: Task) {
     try {
@@ -50,7 +50,6 @@ const store = new Store();
 
 function App() {
   return <Todo store={store} />
-
 }
 const Todo: React.FC<{ store: Store }> = observer(({ store }) => {
   useEffect(() => {
@@ -68,13 +67,13 @@ const Todo: React.FC<{ store: Store }> = observer(({ store }) => {
             <div key={task.id}>
               <input type="checkbox"
                 checked={task.completed}
-                onChange={action(e => {
+                onChange={(e => {
                   const prev = task.completed;
                   task.completed = e.target.checked;
                 })} />
               <input
                 value={task.title}
-                onChange={action(e => task.title = e.target.value)} />
+                onChange={(e => task.title = e.target.value)} />
               <button onClick={() => store.saveTask(task)}>Save</button>
               <button onClick={() => store.deleteTask(task)}>Delete</button>
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,12 +21,12 @@ const App = observer(() => {
             <div key={task.id}>
               <input type="checkbox"
                 checked={task.completed}
-                onChange={action(e => task.completed = e.target.checked)} />
+                onChange={e => task.completed = e.target.checked} />
               <input
                 value={task.title}
-                onChange={action(e => task.title = e.target.value)} />
+                onChange={e => task.title = e.target.value} />
               <button type="button" onClick={() => store.saveTask(task)}>Save</button>
-              <button type="button" onClick={() => store.deleteTask(task)}>Delete</button>
+              <button type="button" onClick={() => task.delete()}>Delete</button>
             </div>
           );
         })}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const App = observer(() => {
                 onChange={e => task.title = e.target.value} />
               <button type="button" onClick={() => store.saveTask(task)}>Save</button>
               <button type="button" onClick={() => task.delete()}>Delete</button>
+              <span>{task.$.title.error}</span>
             </div>
           );
         })}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,9 @@ class Store {
   hideCompleted = false;
   constructor() {
     makeAutoObservable(this);
+    this.taskRepo.addEventListener({
+      deleted: action(task => this.tasks.remove(task))
+    });
   }
   replaceTasks(t: Task[]) {
     this.tasks.replace(t);
@@ -28,18 +31,6 @@ class Store {
   }
   addTask() {
     this.tasks.push(this.taskRepo.create())
-  }
-  async saveTask(task: Task) {
-    try {
-      const savedTask = await this.taskRepo.save(task);
-      runInAction(() => store.tasks[store.tasks.indexOf(task)] = savedTask);
-    } catch (error: any) {
-      alert(error.message);
-    }
-  }
-  async deleteTask(task: Task) {
-    await this.taskRepo.delete(task);
-    runInAction(() => store.tasks.remove(task));
   }
   async setAll(completed: boolean) {
     await TasksController.setAll(completed);
@@ -74,8 +65,15 @@ const Todo: React.FC<{ store: Store }> = observer(({ store }) => {
               <input
                 value={task.title}
                 onChange={(e => task.title = e.target.value)} />
-              <button onClick={() => store.saveTask(task)}>Save</button>
-              <button onClick={() => store.deleteTask(task)}>Delete</button>
+              <button onClick={async () => {
+                try {
+                  await task.save();
+                } catch (error: any) {
+                  alert(error.message);
+                }
+              }}>Save</button>
+              <button onClick={() => task.delete()}>Delete</button>
+              <span>{task.$.title.error}</span>
             </div>
           );
         })}

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -32,8 +32,7 @@ export class Store {
   }
   async saveTask(task: Task) {
     try {
-      const savedTask = await task.save();
-      runInAction(() => store.tasks[store.tasks.indexOf(task)] = savedTask);
+      await task.save();
     } catch (error: any) {
       alert(error.message);
     }

--- a/src/shared/Task.ts
+++ b/src/shared/Task.ts
@@ -1,5 +1,3 @@
-
-import { makeAutoObservable } from "mobx";
 import { Allow, Entity, EntityBase, Fields, Validators } from "remult";
 import { Roles } from "./Roles";
 
@@ -9,18 +7,13 @@ import { Roles } from "./Roles";
       allowApiInsert: Roles.admin,
       allowApiDelete: Roles.admin
 })
-
 export class Task extends EntityBase {
-      constructor(){
-         super();
-         makeAutoObservable(this);
-      }
       @Fields.uuid()
       id!: string;
 
       @Fields.string({
-            validate: Validators.required,
-            allowApiUpdate: Roles.admin
+         validate: Validators.required,
+         allowApiUpdate: Roles.admin
       })
       title = '';
 

--- a/src/shared/Task.ts
+++ b/src/shared/Task.ts
@@ -1,4 +1,4 @@
-import { Allow, Entity, Fields, Validators } from "remult";
+import { Allow, Entity, EntityBase, Fields, Validators } from "remult";
 import { Roles } from "./Roles";
 
 @Entity<Task>("tasks", {
@@ -7,13 +7,13 @@ import { Roles } from "./Roles";
       allowApiInsert: Roles.admin,
       allowApiDelete: Roles.admin
 })
-export class Task {
+export class Task extends EntityBase {
       @Fields.uuid()
       id!: string;
 
       @Fields.string({
-         validate: Validators.required,
-         allowApiUpdate: Roles.admin
+            validate: Validators.required,
+            allowApiUpdate: Roles.admin
       })
       title = '';
 


### PR DESCRIPTION
In this sample, I employ the ActiveRecord pattern - to give more responsibility to the Entity.

This opens up a lot of capabilities that makes the development a lot easier.
For example, instead of:
```ts
await taskRepo.save(task);
```
You can use
```ts
await task.save()
```

Also - there is a lot of metadata that can be extracted and used in the ui or as part of the business logic for example:
```ts
task.$.title.originalValue  //display the originalValue - as it was when the row was last loaded
```
Or
```ts
task.$.title.error //displays validation errors for the `title` field if exist
```
Or
```ts
task.$.title.metadata.caption
```

I would love to get your take on this

